### PR TITLE
Expand pydoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ All components which depend on `libhyperonc` are built using
 [CMake](https://cmake.org/) build tool in order to manage dependencies
 automatically.
 
-Diagram below demonstrates main components and dependencies between them:
+The diagram below demonstrates main components and dependencies between them:
 ![Diagram of the structure](./docs/assets/structure.svg)
 [Source code of the diagram](./docs/assets/structure.plantuml)
 

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -332,10 +332,72 @@ class OperationObject(GroundedObject):
         return isinstance(other, OperationObject) and self.name == other.name
 
 class MatchableObject(ValueObject):
+    """
+    Represents an object that can be involved in a matching operation with an Atom.
+
+    This class is meant to be subclassed by objects that define specific matching behavior
+    with an Atom. It provides a stub method for the matching operation that raises
+    a RuntimeError when called, which must be overridden by subclasses.
+
+    Inherits:
+        ValueObject: The parent class that provides basic value-based equality and representation.
+
+    Methods:
+        match_(atom): A stub method for matching the object with an Atom.
+
+    Example:
+        class MyMatchableObject(MatchableObject):
+            def match_(self, atom):
+                # Implement the matching logic here
+                pass
+
+        my_obj = MyMatchableObject("some_value")
+        my_obj.match_(some_atom)  # Should not raise RuntimeError
+
+    Raises:
+        RuntimeError: Raised when the match_ method is called without being overridden by a subclass.
+    """
+
     def match_(self, atom):
+        """
+        A stub method for matching the object with an Atom.
+
+        This method is intended to be overridden by subclasses to provide specific
+        matching behavior with an Atom.
+
+        Parameters:
+            atom (Atom): An Atom object to match against.
+
+        Raises:
+            RuntimeError: Raised when this method is called without being overridden in a subclass.
+        """
         raise RuntimeError("MatchableObject::match_() is not implemented")
 
 def _type_sugar(type_names):
+    """
+    Transforms a variety of type representations into a unified Atom-based format.
+
+    This utility function is intended for internal use to handle different ways in which
+    type information can be provided. It converts `type_names` into a form that can be
+    readily used for type checking or other internal operations.
+
+    Parameters:
+        type_names (Union[None, list, str, AtomType]): The type information to be converted.
+            - If None, will return AtomType.UNDEFINED.
+            - If list, will recursively transform each element.
+            - If str, will return a Variable Atom (`V`) if the string starts with '$'; otherwise, returns a Symbol Atom (`S`).
+            - If already an AtomType, returns it as is.
+
+    Returns:
+        AtomType: The transformed type information in AtomType format.
+
+    Examples:
+        _type_sugar(None)                 => AtomType.UNDEFINED
+        _type_sugar(["int", "str"])       => E(S("->"), S("int"), S("str"))
+        _type_sugar("$var")               => V("var")
+        _type_sugar("int")                => S("int")
+        _type_sugar(AtomType.SOME_TYPE)   => AtomType.SOME_TYPE
+    """
     if type_names is None:
         return AtomType.UNDEFINED
     if isinstance(type_names, list):

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -10,30 +10,29 @@ class Atom:
     """Represents an Atom of any type"""
 
     def __init__(self, catom):
-        """Initialize an atom"""
+        """Initialize an Atom"""
         self.catom = catom
 
     def __del__(self):
-        """Frees an atom and all associated resources."""
+        """Frees an Atom and all associated resources."""
         #import sys; sys.stderr.write("Atom._del_(" + str(self) + ")\n"); sys.stderr.flush()
         hp.atom_free(self.catom)
 
-
     def __eq__(self, other):
-        """Checks if two atom objects represent the same conceptual atom. """
+        """Checks if two atom objects represent the same conceptual Atom."""
         return (isinstance(other, Atom) and
                 hp.atom_eq(self.catom, other.catom))
 
     def __repr__(self):
-        """Renders a human-readable text description of an atom. """
+        """Renders a human-readable text description of the Atom."""
         return hp.atom_to_str(self.catom)
 
     def get_type(self):
-        """Gets the type of this Atom"""
+        """Gets the type of the current Atom instance"""
         return hp.atom_get_type(self.catom)
 
     def iterate(self):
-        """Performs a depth-first exhaustive iteration of an atom and all its children recursively."""
+        """Performs a depth-first exhaustive iteration of an Atom and all its children recursively."""
         res = hp.atom_iterate(self.catom)
         result = []
         for r in res:
@@ -41,7 +40,7 @@ class Atom:
         return result
 
     def match_atom(self, b):
-        """Matches one atom with another, establishing bindings between them."""
+        """Matches one Atom with another, establishing bindings between them."""
         return BindingsSet(hp.atom_match_atom(self.catom, b.catom))
 
     @staticmethod
@@ -57,18 +56,18 @@ class Atom:
         elif type == AtomKind.GROUNDED:
             return GroundedAtom(catom)
         else:
-            raise Exception("Unexpected type of the atom: " + str(type))
+            raise Exception("Unexpected type of the Atom: " + str(type))
 
 class SymbolAtom(Atom):
-    """Symbol Atom represents a single concepts which is identified by name. Two symbols
-    which have the same name reference the same concept."""
+    """A SymbolAtom represents a single concept, identified by name. If two symbols
+    have the same name, they reference the same concept."""
 
     def __init__(self, catom):
-        """Initialize a symbol atom"""
+        """Initialize a SymbolAtom"""
         super().__init__(catom)
 
     def get_name(self):
-        """Renders the name of an atom into a text buffer."""
+        """Renders the name of the Atom into a text buffer."""
         return hp.atom_get_name(self.catom)
 
 def S(name):
@@ -76,16 +75,15 @@ def S(name):
     return SymbolAtom(hp.atom_sym(name))
 
 class VariableAtom(Atom):
-    """
-    Variable Atom represents a variable like a variable in the pattern.
-    """
+    """A VariableAtom represents a variable in an expression. It serves as a
+    placeholder that can be matched with, or bound to other Atoms."""
 
     def __init__(self, catom):
-        """Initialize a variable atom"""
+        """Initialize a VariableAtom"""
         super().__init__(catom)
 
     def get_name(self):
-        """Renders the name of an atom into a text buffer."""
+        """Renders the name of the Atom into a text buffer."""
         return hp.atom_get_name(self.catom)
 
 def V(name):
@@ -93,23 +91,23 @@ def V(name):
     return VariableAtom(hp.atom_var(name))
 
 class ExpressionAtom(Atom):
-    """Expression Atom combines other kinds of atoms including expressions themselves."""
+    """An ExpressionAtom combines different kinds of Atoms, including expressions."""
 
     def __init__(self, catom):
         """Initialize an expression atom"""
         super().__init__(catom)
 
     def get_children(self):
-        """Gets all of the children Atoms"""
+        """Gets all children Atoms"""
         return [Atom._from_catom(catom) for catom in hp.atom_get_children(self.catom)]
 
 
 def E(*args):
-    """A convenient method to construct a ExpressionAtom"""
+    """A convenient method to construct an ExpressionAtom"""
     return ExpressionAtom(hp.atom_expr([atom.catom for atom in args]))
 
 class AtomType:
-    """Defines all the types of Atom"""
+    """Defines all Atom types"""
 
     UNDEFINED = Atom._from_catom(hp.CAtomType.UNDEFINED)
     TYPE = Atom._from_catom(hp.CAtomType.TYPE)
@@ -121,22 +119,23 @@ class AtomType:
     GROUNDED_SPACE = Atom._from_catom(hp.CAtomType.GROUNDED_SPACE)
 
 class GroundedAtom(Atom):
-    """Grounded Atom represents sub-symbolic knowledge. On the API level it allows
-    keeping data and behaviour inside an atom. There are three aspects of the grounded
-    atom which can be customized:
+    """
+    A GroundedAtom represents sub-symbolic knowledge. At the API level, it allows
+    keeping data and behaviour inside an Atom. There are three aspects of a GroundedAtom
+    which can be customized:
 
-        - the type of grounded atom is provided by the atom itself;
-        - matching algorithm of the atom can be modified by the user;
-        - atom can be made executable; such atom can be used to apply some sub-symbolic
-          operations to other atoms as arguments.
+        - the type of GroundedAtom is provided by the Atom itself;
+        - the matching algorithm used by the Atom;
+        - an Atom can be made executable, and used to apply sub-symbolic
+          operations to other Atoms as arguments.
     """
 
     def __init__(self, catom):
-        """Initialize a grounded atom"""
+        """Initialize a GroundedAtom"""
         super().__init__(catom)
 
     def get_object(self):
-        """Gets the Grounded Atom object or the space wrapped inside a Grounded Atom"""
+        """Gets the GroundedAtom object, or the space wrapped inside a GroundedAtom"""
         from .base import SpaceRef
         if self.get_grounded_type() == AtomType.GROUNDED_SPACE:
             return SpaceRef._from_cspace(hp.atom_get_space(self.catom))
@@ -144,7 +143,7 @@ class GroundedAtom(Atom):
             return hp.atom_get_object(self.catom)
 
     def get_grounded_type(self):
-        """Retrieve the grounded type of a Grounded Atom."""
+        """Retrieve the grounded type of the GroundedAtom."""
         return Atom._from_catom(hp.atom_get_grounded_type(self.catom))
 
 def G(object, type=AtomType.UNDEFINED):
@@ -154,7 +153,8 @@ def G(object, type=AtomType.UNDEFINED):
 
 def _priv_call_execute_on_grounded_atom(gnd, typ, args):
     """
-    Private glue for Hyperonpy implementation
+    Private glue for Hyperonpy implementation.
+    Executes grounded Atoms.
     """
     # ... if hp.atom_to_str(typ) == AtomType.UNDEFINED
     res_typ = AtomType.UNDEFINED if hp.atom_get_type(typ) != AtomKind.EXPR \
@@ -164,20 +164,26 @@ def _priv_call_execute_on_grounded_atom(gnd, typ, args):
 
 def _priv_call_match_on_grounded_atom(gnd, catom):
     """
-    Private glue for Hyperonpy implementation
+    Private glue for Hyperonpy implementation.
+    Matches grounded atoms
     """
     return gnd.match_(Atom._from_catom(catom))
 
 def atoms_are_equivalent(first, second):
+    """Check if two atoms are equivalent"""
     return hp.atoms_are_equivalent(first.catom, second.catom)
 
 class GroundedObject:
+    """A GroundedObject holds some content and, optionally, an identifier."""
 
     def __init__(self, content, id=None):
+        """Initializes a new GroundedObject with the given content and identifier."""
         self.content = content
         self.id = id
 
     def __repr__(self):
+        """Returns the object's ID if present, or a string representation of 
+        its content if not."""
         # Overwrite Python default representation of a string to use
         # double quotes instead of single quotes.
         if isinstance(self.content, str):
@@ -187,19 +193,40 @@ class GroundedObject:
         return repr(self.content) if self.id is None else self.id
 
     def copy(self):
+        """
+        Returns a copy of this GroundedObject instance.
+
+        Note: Currently, this method returns the original
+        instance, effectively making the GroundedObject immutable.
+        """
         return self
 
 class ValueObject(GroundedObject):
+    """
+    A ValueObject is a specialized form of GroundedObject, which treats its content
+    as a value. It allows for equality comparison between the content of two ValueObjects.
+
+    Example:
+        obj1 = ValueObject(5)
+        obj2 = ValueObject(5)
+        obj3 = ValueObject(6)
+        
+        print(obj1 == obj2)  # True
+        print(obj1 == obj3)  # False
+    """
 
     @property
     def value(self):
+        """Gets the value of the object, which is its content."""
         return self.content
 
     def __eq__(self, other):
-        # TODO: ?typecheck
+        """Compares the equality of this ValueObject with another based on their content."""
+        # TODO: ?typecheck for the contents
         return isinstance(other, ValueObject) and self.content == other.content
 
 class NoReduceError(Exception):
+    """Custom exception raised when a reduction operation cannot be performed."""
     pass
 
 class OperationObject(GroundedObject):
@@ -223,7 +250,7 @@ class OperationObject(GroundedObject):
                 if not isinstance(arg, GroundedAtom):
                     # REM:
                     # Currently, applying grounded operations to pure atoms is not reduced.
-                    # If we want, we can raise an exception, or to form a error expression instead,
+                    # If we want, we can raise an exception, or form an error expression instead,
                     # so a MeTTa program can catch and analyze it.
                     # raise RuntimeError("Grounded operation " + self.name + " with unwrap=True expects only grounded arguments")
                     raise NoReduceError()

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -196,8 +196,7 @@ class GroundedObject:
         """
         Returns a copy of this GroundedObject instance.
 
-        Note: Currently, this method returns the original
-        instance, effectively making the GroundedObject immutable.
+        Note: Currently, this method returns the original instance.
         """
         return self
 
@@ -226,7 +225,7 @@ class ValueObject(GroundedObject):
         return isinstance(other, ValueObject) and self.content == other.content
 
 class NoReduceError(Exception):
-    """Custom exception raised when a reduction operation cannot be performed."""
+    """Custom exception; raised when a reduction operation cannot be performed."""
     pass
 
 class OperationObject(GroundedObject):
@@ -496,12 +495,12 @@ class Bindings:
         return None if raw_atom is None else Atom._from_catom(raw_atom)
 
     def resolve_and_remove(self, var_name: str) -> Union[Atom, None]:
-        """Finds anr removes the atom for a given variable name"""
+        """Finds and removes the atom for a given variable name"""
         raw_atom = hp.bindings_resolve_and_remove(self.cbindings, var_name)
         return None if raw_atom is None else Atom._from_catom(raw_atom)
 
     def iterator(self):
-        """Iterates through all variable-atom pairs in the bindings"""
+        """Returns an iterator over the variable-atom pairs in the bindings"""
         res = hp.bindings_list(self.cbindings)
         result = []
         for r in res:
@@ -617,7 +616,7 @@ class BindingsSet:
             hp.bindings_set_merge_into(self.c_set, new_set.c_set);
 
     def iterator(self):
-        """Iterates through all Bindings frames."""
+        """Returns an iterator over all Bindings frames"""
         res = hp.bindings_set_list(self.c_set)
         result = []
         for r in res:

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -230,20 +230,77 @@ class NoReduceError(Exception):
     pass
 
 class OperationObject(GroundedObject):
+    """
+    An OperationObject represents an operation as a grounded object, allowing for more
+    advanced logic like lazy evaluation, type-checking, and more.
+
+    Inherits:
+        GroundedObject: The parent class that provides the basic wrapper around content.
+
+    Attributes:
+        unwrap (bool): Determines whether to unwrap the content of GroundedAtoms
+                       when passed as arguments to the operation.
+
+    Properties:
+        op: Returns the operation function.
+        name: Returns the identifier name for this operation object.
+
+    Methods:
+        __init__(name, op, unwrap): Initializes an OperationObject instance.
+        execute(*args, res_typ): Executes the operation with the provided arguments.
+        __eq__(other): Compares the equality of this OperationObject instance with another.
+
+    Example:
+        def add(a, b):
+            return a + b
+
+        op_obj = OperationObject("addition", add)
+        result = op_obj.execute(3, 4)
+    """
 
     def __init__(self, name, op, unwrap=True):
+        """
+        Initializes a new OperationObject with a name identifier, operation function,
+        and an optional unwrap flag.
+        Parameters:
+            name (str): The identifier for this operation.
+            op (function): The function representing the operation.
+            unwrap (bool, optional): Whether to unwrap GroundedAtom content when applying
+                                     the operation. Defaults to True.
+
+        """
         super().__init__(op, name)
         self.unwrap = unwrap
 
     @property
     def op(self):
+        """Returns the operation function."""
         return self.content
 
     @property
     def name(self):
+        """Returns the identifier name for this operation object."""
         return self.id
 
     def execute(self, *args, res_typ=AtomType.UNDEFINED):
+        """
+        Executes the operation with the provided arguments.
+
+        Parameters:
+            *args: Arguments to pass to the operation function.
+            res_typ (AtomType, optional): The expected result type. Defaults to AtomType.UNDEFINED.
+
+        Returns:
+            The result of the operation.
+
+        Raises:
+            NoReduceError: Raised when `unwrap=True` and a non-GroundedAtom argument is provided.
+            RuntimeError: Raised when the result of the operation is not a list.
+
+        Note:
+            Depending on the `unwrap` attribute, this method will either unwrap GroundedAtoms
+            before passing them to the operation or pass them as is.
+        """
         # type-check?
         if self.unwrap:
             for arg in args:
@@ -263,6 +320,15 @@ class OperationObject(GroundedObject):
             return result
 
     def __eq__(self, other):
+        """
+        Compares the equality of this OperationObject with another based on their names.
+
+        Parameters:
+            other (OperationObject): Another OperationObject instance to compare.
+
+        Returns:
+            True if both OperationObjects have the same name; False otherwise.
+        """
         return isinstance(other, OperationObject) and self.name == other.name
 
 class MatchableObject(ValueObject):

--- a/python/hyperon/base.py
+++ b/python/hyperon/base.py
@@ -7,11 +7,13 @@ class AbstractSpace:
     A virtual base class upon which Spaces can be implemented in Python
     """
     def __init__(self):
+        """Initialiize the AbstractSpace. Does nothing in the base class"""
         return
 
     def query(self, query_atom):
         """
-        Performs the specified query on the Space, and returns the result BindingsSet
+        Performs the specified query on the Space.
+        Should be overridden to return a BindingsSet as the result of the query.
         """
         raise RuntimeError("Space::query() is not implemented")
 
@@ -21,38 +23,50 @@ class AbstractSpace:
     #     None
 
     def add(self, atom):
-        """Adds an atom to the atom space"""
+        """
+        Adds an Atom to the atom space. Must be implemented in derived classes.
+        """
         raise RuntimeError("Space::add() is not implemented")
 
     def remove(self, atom):
-        """Removes an atom from the atom space"""
+        """
+        Removes an Atom from the atom space. Must be implemented in derived classes.
+        """
         raise RuntimeError("Space::remove() is not implemented")
 
     def replace(self, atom, replacement):
-        """Replaces an atom in the atom space"""
+        """
+        Replaces an Atom from the atom space. Must be implemented in derived classes.
+        """
         raise RuntimeError("Space::replace() is not implemented")
 
     def atom_count(self):
-        """Counts the number of atoms in the atom space"""
+        """
+        Counts the number of atoms in the atom space. Optional for derived classes.
+        """
         None
 
     def atoms_iter(self):
-        """Gets the atom iterator"""
+        """
+        Returns an iterator over atoms in the Space. Optional for derived classes.
+        """
         None
 
 class GroundingSpace(AbstractSpace):
     """
-    A wrapper over the native GroundingSpace implementation, that can be subclassed 
+    A wrapper over the native GroundingSpace implementation, which can be subclassed
     and extended within Python
     """
     def __init__(self, unwrap=True):
+        """Initialize GroundingSpace and its underlying native implementation."""
         super().__init__()
         # self.cspace = hp.space_new_grounding()
         self.gspace = GroundingSpaceRef()
 
     def query(self, query_atom):
         """
-        Performs the specified query on the Space, and returns the result BindingsSet
+        Delegates the query to the underlying native GroundingSpace
+        and returns the result BindingsSet
         """
         return self.gspace.query(query_atom)
 
@@ -60,49 +74,67 @@ class GroundingSpace(AbstractSpace):
     # def subst(self, pattern, templ):
 
     def add(self, atom):
-        """Adds an atom to the atom space"""
+        """
+        Adds an Atom to the atom space.
+        """
         self.gspace.add_atom(atom)
 
     def remove(self, atom):
-        """Removes an atom from the atom space"""
+        """
+        Removes an Atom from the atom space.
+        """
         return self.gspace.remove_atom(atom)
 
     def replace(self, from_atom, to_atom):
-        """Replaces an atom in the atom space"""
+        """
+        Replaces an Atom in the atom space.
+        """
         return self.gspace.replace_atom(from_atom, to_atom)
 
     def atom_count(self):
-        """Counts the number of atoms in the atom space"""
+        """
+        Counts the number of Atoms in the atom space.
+        """
         return self.gspace.atom_count()
 
     def atoms_iter(self):
-        """Gets the atom iterator"""
+        """
+        Returns an iterator over atoms in the atom space.
+        """
         return iter(self.gspace.get_atoms())
 
 def _priv_call_query_on_python_space(space, query_catom):
     """
-    Private glue for Hyperonpy implementation
+    Private glue for Hyperonpy implementation.
+    Translates a native 'catom' into an Atom object, and then delegates the query
+    to the provided 'space' object.
     """
     query_atom = Atom._from_catom(query_catom)
     return space.query(query_atom)
 
 def _priv_call_add_on_python_space(space, catom):
     """
-    Private glue for Hyperonpy implementation
+    Private glue for Hyperonpy implementation.
+    Translates a native 'catom' into an Atom object, and then adds it
+    to the provided 'space' object.
     """
     atom = Atom._from_catom(catom)
     space.add(atom)
 
 def _priv_call_remove_on_python_space(space, catom):
     """
-    Private glue for Hyperonpy implementation
+    Private glue for Hyperonpy implementation.
+    Translates a native 'catom' into an Atom object, and then removes it
+    from the provided 'space' object.
     """
     atom = Atom._from_catom(catom)
     return space.remove(atom)
 
 def _priv_call_replace_on_python_space(space, cfrom, cto):
     """
-    Private glue for Hyperonpy implementation
+    Private glue for Hyperonpy implementation.
+    Translates native 'catom' objects into Atom objects, and then replaces
+    the first with the second in the provided 'space' object.
     """
     from_atom = Atom._from_catom(cfrom)
     to_atom = Atom._from_catom(cto)
@@ -110,7 +142,8 @@ def _priv_call_replace_on_python_space(space, cfrom, cto):
 
 def _priv_call_atom_count_on_python_space(space):
     """
-    Private glue for Hyperonpy implementation
+    Private glue for Hyperonpy implementation.
+    Returns the number of Atoms in the provided 'space' object.
     """
     if hasattr(space, "atom_count"):
         count = space.atom_count()
@@ -123,7 +156,8 @@ def _priv_call_atom_count_on_python_space(space):
 
 def _priv_call_new_iter_state_on_python_space(space):
     """
-    Private glue for Hyperonpy implementation
+    Private glue for Hyperonpy implementation.
+    Returns an iterator over Atoms in the provided 'space' object.
     """
     if hasattr(space, "atoms_iter"):
         return space.atoms_iter()
@@ -133,58 +167,67 @@ def _priv_call_new_iter_state_on_python_space(space):
 class SpaceRef:
     """
     A reference to a Space, which may be accessed directly, wrapped in a grounded atom,
-    or passed to a MeTTa interpreter
+    or passed to a MeTTa interpreter.
     """
 
     def __init__(self, space_obj):
+        """
+        Initialize a new SpaceRef based on the given space object, either a CSpace 
+        or a custom Python object.
+        """
         if type(space_obj) is hp.CSpace:
             self.cspace = space_obj
         else:
             self.cspace = hp.space_new_custom(space_obj)
 
     def __del__(self):
+        """Free the underlying CSpace object """
         hp.space_free(self.cspace)
 
     def __eq__(self, other):
+        """Compare two SpaceRef objects for equality, based on their underlying spaces."""
         return hp.space_eq(self.cspace, other.cspace)
 
     @staticmethod
     def _from_cspace(cspace):
+        """
+        Create a new SpaceRef based on the given CSpace object.
+        """
         return SpaceRef(cspace)
 
     def copy(self):
         """
-        Returns a new copy of the SpaceRef, referencing the same underlying Space
+        Returns a new copy of the SpaceRef, referencing the same underlying Space.
         """
         return self
 
     def add_atom(self, atom):
         """
-        Add an Atom to the Space
+        Add an Atom to the Space.
         """
         hp.space_add(self.cspace, atom.catom)
 
     def remove_atom(self, atom):
         """
-        Delete the specified atom from the Space
+        Delete the specified Atom from the Space.
         """
         return hp.space_remove(self.cspace, atom.catom)
 
     def replace_atom(self, atom, replacement):
         """
-        Replace the specified Atom, if it exists in the Space, with the supplied replacement Atom
+        Replaces an existing Atom in the Space with a new one.
         """
         return hp.space_replace(self.cspace, atom.catom, replacement.catom)
 
     def atom_count(self):
         """
-        Returns the number of Atoms in the Space, or -1 if it cannot readily computed
+        Returns the number of Atoms in the Space, or -1 if it cannot be readily computed.
         """
         return hp.space_atom_count(self.cspace)
 
     def get_atoms(self):
         """
-        Returns a list of all Atoms in the Space, or None if that is impossible
+        Returns a list of all Atoms in the Space, or None if that is impossible.
         """
         res = hp.space_list(self.cspace)
         if res == None:
@@ -197,20 +240,20 @@ class SpaceRef:
     def get_payload(self):
         """
         Returns the Space object referenced by the SpaceRef, or None if the object does not have a
-        direct Python interface
+        direct Python interface.
         """
         return hp.space_get_payload(self.cspace)
 
     def query(self, pattern):
         """
-        Performs the specified query on the Space, and returns the result BindingsSet
+        Performs the specified query on the Space, and returns the result as a BindingsSet.
         """
         result = hp.space_query(self.cspace, pattern.catom)
         return BindingsSet(result)
 
     def subst(self, pattern, templ):
         """
-        Performs a substitution within the Space
+        Performs a substitution within the Space, based on a pattern and a template.
         """
         return [Atom._from_catom(catom) for catom in
                 hp.space_subst(self.cspace, pattern.catom,
@@ -218,10 +261,16 @@ class SpaceRef:
 
 class GroundingSpaceRef(SpaceRef):
     """
-    A reference to a native GroundingSpace, implemented by the MeTTa core library
+    A reference to a native GroundingSpace, implemented by the MeTTa core library.
+    This class extends SpaceRef to provide the same set of functionalities,
+    specifically for GroundingSpaces.
     """
 
     def __init__(self, cspace = None):
+        """
+        Initialize a new GroundingSpaceRef.
+        If a CSpace object is provided, use it; otherwise create a new GroundingSpace.
+        """
         if cspace is None:
             self.cspace = hp.space_new_grounding()
         else:
@@ -229,11 +278,21 @@ class GroundingSpaceRef(SpaceRef):
 
     @staticmethod
     def _from_cspace(cspace):
+        """
+        Creates a GroundingSpaceRef from a CSpace object.
+        """
         return GroundingSpaceRef(cspace)
 
 class Tokenizer:
+    """
+    A class responsible for text tokenization in the context of Hyperon.
+    This class wraps around a CTokenizer object from the core library.
+    """
 
     def __init__(self, ctokenizer = None):
+        """
+        Initialize a new Tokenizer.
+        """
         if ctokenizer is None:
             self.ctokenizer = hp.tokenizer_new()
         else:
@@ -241,75 +300,104 @@ class Tokenizer:
 
     @staticmethod
     def _from_ctokenizer(ctokenizer):
+        """
+        Creates a Tokenizer from a CTokenizer object.
+        """
         return Tokenizer(ctokenizer)
 
     def __del__(self):
+        """
+        Destructor that frees the CTokenizer object when the Tokenizer instance is destroyed.
+        """
         hp.tokenizer_free(self.ctokenizer)
 
     def register_token(self, regex, constr):
-        """Registers a new custom Token in a Tokenizer.
-
-        Hyperon uses the Rust RegEx engine and syntax
-        https://docs.rs/regex/latest/regex/
-
-        Parameters
-        ----------
-        regex: 
-            A regular expression to match the incoming text, triggering this token to
-            generate a new atom
         """
+        Registers a new custom Token in the Tokenizer based on a regular expression.
+
+        Parameters:
+        ----------
+        regex:
+           A string representing the regular expression to match incoming text.
+           Hyperon uses the Rust RegEx engine and syntax.
+       constr:
+           A constructor function for generating a new atom when the regex is triggered.
+       """
         hp.tokenizer_register_token(self.ctokenizer, regex, constr)
 
 class SExprParser:
+    """
+    A class responsible for parsing S-expressions (Symbolic Expressions).
+    This class wraps around a CSExprParser object from the core library.
+    """
 
     def __init__(self, text):
+        """Initialize a new SExprParser object."""
         self.cparser = hp.CSExprParser(text)
 
     def parse(self, tokenizer):
+        """
+        Parses the S-expression using the provided Tokenizer.
+        """
         catom = self.cparser.parse(tokenizer.ctokenizer)
         return Atom._from_catom(catom) if catom is not None else None
 
 class Interpreter:
+    """
+    A wrapper class for the MeTTa interpreter that handles the interpretation of expressions in a given grounding space.
+    """
 
     def __init__(self, gnd_space, expr):
+        """
+        Initializes the interpreter with the given grounded space and expression.
+        """
         self.step_result = hp.interpret_init(gnd_space.cspace, expr.catom)
 
     def has_next(self):
-        """Examines a Step Result to determine if more work is needed."""
+        """
+        Checks if there are more steps to execute in the interpretation plan.
+        """
         return hp.step_has_next(self.step_result)
 
     def next(self):
-        """Moves to the next Step Result"""
+        """
+        Executes the next step in the interpretation plan.
+        """
         if not self.has_next():
             raise StopIteration()
         self.step_result = hp.interpret_step(self.step_result)
 
     def get_result(self):
-        """Consumes a Step Result and provides the ultimate outcome of a MeTTa
-        interpreter session.
+        """
+        Retrieves the final outcome of the interpretation plan.
         """
         if self.has_next():
             raise RuntimeError("Plan execution is not finished")
         return hp.step_get_result(self.step_result)
 
     def get_step_result(self):
-        """Gets the current Step Result"""
+        """
+        Gets the current result of the interpretation plan.
+        """
         return self.step_result
 
 
 def interpret(gnd_space, expr):
-    """Parses the expression in the grounded space"""
+    """
+    Parses the given expression in the specified grounded space.
+    """
     interpreter = Interpreter(gnd_space, expr)
     while interpreter.has_next():
         interpreter.next()
     return [Atom._from_catom(catom) for catom in interpreter.get_result()]
 
 def check_type(gnd_space, atom, type):
-    """Checks whether the atom has the type `type` in context of space
+    """
+    Checks whether the given Atom has the specified type in the given space context.
 
     Parameters
     ----------
-    space:
+    gnd_space:
         A pointer to the space_t representing the space context in which to perform
         the check
     atom:
@@ -322,7 +410,8 @@ def check_type(gnd_space, atom, type):
     return hp.check_type(gnd_space.cspace, atom.catom, type.catom)
 
 def validate_atom(gnd_space, atom):
-    """Checks whether atom is correctly typed.
+    """
+    Checks whether the given Atom is correctly typed.
 
     Parameters
     ----------
@@ -335,11 +424,11 @@ def validate_atom(gnd_space, atom):
 
     Returns
     -------
-    if the Atom is correctly typed, otherwise false
+    True if the Atom is correctly typed, otherwise false
     """
     return hp.validate_atom(gnd_space.cspace, atom.catom)
 
 def get_atom_types(gnd_space, atom):
-    """Provides all types for atom in the context of space"""
+    """Provides all types for the given Atom in the context of the given Space."""
     result = hp.get_atom_types(gnd_space.cspace, atom.catom)
     return [Atom._from_catom(catom) for catom in result]

--- a/python/hyperon/base.py
+++ b/python/hyperon/base.py
@@ -215,7 +215,7 @@ class SpaceRef:
 
     def replace_atom(self, atom, replacement):
         """
-        Replaces an existing Atom in the Space with a new one.
+        Replaces the specified Atom, if it exists in the Space, with the supplied replacement.
         """
         return hp.space_replace(self.cspace, atom.catom, replacement.catom)
 

--- a/python/hyperon/ext.py
+++ b/python/hyperon/ext.py
@@ -1,18 +1,30 @@
 from .runner import MeTTa
 
 def register_results(method, args, kwargs):
+    """Returns a decorator for registering the results of a method.
+    The behavior of the decorator depends on whether it is used with or without arguments."""
+    
+    # Case 1: Decorator used without arguments (i.e., @decorator instead of @decorator(args))
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
-        # no arguments
-        func = args[0]
+        func = args[0]  # func is the decorated function
+
+        # Define the decorator
         def metta_register(metta):
+            # Register the results of calling the decorated function using the provided method
             method(metta, func())
         return metta_register
+
+    # Case 2: Decorator used with arguments (i.e., @decorator(args))
     else:
-        # with arguments
+        # Check if the decorator is used with arguments
         pass_metta = kwargs.get('pass_metta', False)
+
+        # Define the decorator
         def inner(func):
             def metta_register(metta):
+                # Get the results of calling the decorated function
                 regs = func(metta) if pass_metta else func()
+                # Register the results using the provided method
                 method(metta, regs)
             return metta_register
         return inner

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -38,7 +38,7 @@ class MeTTa:
         self.tokenizer().register_token(regexp, constr)
 
     def register_atom(self, name, symbol):
-        """Registers an atom"""
+        """Registers an Atom"""
         self.register_token(name, lambda _: symbol)
 
     def _parse_all(self, program):
@@ -58,7 +58,7 @@ class MeTTa:
         return next(self._parse_all(program))
 
     def load_py_module(self, name):
-        """Loads the give python module"""
+        """Loads the given python module"""
         if not isinstance(name, str):
             name = repr(name)
         mod = import_module(name)
@@ -68,7 +68,7 @@ class MeTTa:
                 obj(self)
 
     def import_file(self, fname):
-        """Loads the program file and run it"""
+        """Loads the program file and runs it"""
         path = fname.split(os.sep)
         if len(path) == 1:
             path = ['.'] + path


### PR DESCRIPTION
Revision of documentation.
I got help from code generators to improve on the docstrings, so some of them may be too verbose.
They tend to be very clear, and perhaps we want this kind of documentation?

For an example of what they could provide, please look at the `OperationObject` and `MatchableObject` classes in python/hyperon/atoms.py